### PR TITLE
Init FCFS Scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # microservice-fcfs
-Microservice to implement the First Come First Server algorithm
+Microservice to implement the First Come First Server algorithm.

--- a/SchedulingModel.py
+++ b/SchedulingModel.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class SchedulingModel(BaseModel):
+    schedule: list[int]
+    lcm: int

--- a/TaskModel.py
+++ b/TaskModel.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class TaskModel(BaseModel):
+    executionTime: int
+    period: int
+    arrivalTime: int
+    deadline: int

--- a/fcfs.py
+++ b/fcfs.py
@@ -1,0 +1,112 @@
+import TaskModel
+from SchedulingModel import SchedulingModel
+
+
+# Function to find the waiting time
+# for all processes
+def findWaitingTime(processes, n, bt, wt, at):
+    service_time = [0] * n
+    service_time[0] = 0
+    wt[0] = 0
+
+    # calculating waiting time
+    for i in range(1, n):
+
+        # Add burst time of previous processes
+        service_time[i] = (service_time[i - 1] +
+                           bt[i - 1])
+
+        # Find waiting time for current
+        # process = sum - at[i]
+        wt[i] = service_time[i] - at[i]
+
+        # If waiting time for a process is in
+        # negative that means it is already
+        # in the ready queue before CPU becomes
+        # idle so its waiting time is 0
+        if wt[i] < 0:
+            wt[i] = 0
+
+
+# Function to calculate turn around time
+def findTurnAroundTime(processes, n, bt, wt, tat):
+    # Calculating turnaround time by
+    # adding bt[i] + wt[i]
+    for i in range(n):
+        tat[i] = bt[i] + wt[i]
+
+    # Function to calculate average waiting
+
+
+# and turn-around times.
+# TODO: Call this function to get the avg time, not implemented
+def findAvgTime(processes, n, bt, at):
+    startingPoints = []
+    endingPoints = []
+    tasks = []
+    wt = [0] * n
+    tat = [0] * n
+
+    # Function to find waiting time
+    # of all processes
+    findWaitingTime(processes, n, bt, wt, at)
+
+    # Function to find turn around time for
+    # all processes
+    findTurnAroundTime(processes, n, bt, wt, tat)
+
+    total_wt = 0
+    total_tat = 0
+    lcm = 0
+    for i in range(n):
+        total_wt = total_wt + wt[i]
+        total_tat = total_tat + tat[i]
+        compl_time = tat[i] + at[i]
+        if lcm < compl_time:
+            lcm = compl_time
+
+        startingPoints.append(at[i] + wt[i])
+        endingPoints.append(compl_time)
+        tasks.append(i + 1)
+
+    print("Average waiting time = %.5f " % (total_wt / n))
+    print("Average turn around time = ", total_tat / n)
+
+
+def schedule(processesArray: list[TaskModel], executionTimeArray: list[int], periodArray: list[int],
+             arrivalTimeArray: list[int]):
+    exec_count = 0
+    stack = []
+    LCM = max((map(lambda x: x.period, processesArray)))
+    while 1:
+        ind = 0
+        for j in range(0, len(processesArray)):
+            if LCM % processesArray[j].period == 0:
+                ind = ind + 1
+        if ind == len(processesArray):
+            break
+        else:
+            LCM = LCM + 1
+    print("Timeline length =", LCM)
+    resultStartingPoints = list(range(LCM + 1))
+    resultArray = [0] * LCM
+    task = 0
+    for i in range(0, LCM):
+        if i in arrivalTimeArray:
+            stack.extend(k for k, x in enumerate(arrivalTimeArray) if x == i)
+        if exec_count == 0 and len(stack) != 0:
+            task = stack[0]
+            exec_count = executionTimeArray[task]
+            period = periodArray[task]
+            arrivalTimeArray[task] = arrivalTimeArray[task] + period
+            resultArray[i] = task + 1
+            exec_count = exec_count - 1
+        elif len(stack) != 0:
+            resultArray[i] = task + 1
+            exec_count = exec_count - 1
+
+        if exec_count == 0 and len(stack) != 0:
+            stack.pop(0)
+            task = 0
+    schedulingModel = SchedulingModel(schedule=resultArray, lcm=LCM)
+    return schedulingModel

--- a/main.py
+++ b/main.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI
+from TaskModel import TaskModel
+from SchedulingModel import SchedulingModel
+import fcfs
+
+app = FastAPI()
+
+
+@app.get("/fcfs/")
+async def root():
+    return {"name": "First Come First Serve"}
+
+
+# TODO: Add log statements to the response for remarks which displays input, avg time etc,.
+@app.get("/fcfs/schedule/", response_model=SchedulingModel)
+async def schedule(tasks: list[TaskModel]):
+    executionTimeArray = []
+    arrivalTimeArray = []
+    periodArray = []
+    tasks.sort(key=lambda x: x.executionTime)
+    for task in tasks:
+        executionTimeArray.append(task.executionTime)
+        periodArray.append(task.period)
+        arrivalTimeArray.append(task.arrivalTime)
+    schedulingModel = fcfs.schedule(tasks, executionTimeArray, periodArray, arrivalTimeArray)
+    return schedulingModel

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,20 @@
+# Test your FastAPI endpoints
+# TODO: Add more unit tests
+
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def test_fcfs_home():
+    response = client.get("/fcfs/")
+    assert response.status_code == 200
+    assert response.json() == {"name": "First Come First Serve"}
+
+
+def test_fcfs_schedule():
+    response = client.get("/fcfs/schedule", data="[{\"executionTime\": 1,\"period\": 8,\"arrivalTime\": 8,"
+                                                 "\"deadline\": 0}]")
+    assert response.status_code == 200
+    assert response.json() == {"schedule": [0, 0, 0, 0, 0, 0, 0, 0], "lcm": 8}


### PR DESCRIPTION
Using [FastAPI](https://fastapi.tiangolo.com/) to create a microservice for FCFS.
To Test:
1. Clone and run in venv of Python 3.9 or greater
2. Use postman or any other tools
3. GET for the path `http://127.0.0.1:8000/fcfs/schedule/`

Example Body:
```
[
    {
        "executionTime": 1,
        "period": 8,
        "arrivalTime": 8,
        "deadline": 0
    },
    {
        "executionTime": 3,
        "period": 15,
        "arrivalTime": 15,
        "deadline": 0
    },
    {
        "executionTime": 6,
        "period": 22,
        "arrivalTime": 22,
        "deadline": 0
    }
]
```